### PR TITLE
fix: replace styles and states, calculate isSupported only once 

### DIFF
--- a/src/TranslateContext.tsx
+++ b/src/TranslateContext.tsx
@@ -33,7 +33,7 @@ export const IOSTranslateSheetProvider = ({
         text={text}
         isPresented={isIOSTranslateSheetPresented}
         onHide={hideTranslateSheet}
-        style={styles.translateView}
+        style={StyleSheet.absoluteFillObject}
         opacity={opacity}
       />
       {children}
@@ -50,13 +50,3 @@ export const useIOSTranslateSheet = () => {
   }
   return context;
 };
-
-const styles = StyleSheet.create({
-  translateView: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
-});

--- a/src/hooks/useInternalTranslate.tsx
+++ b/src/hooks/useInternalTranslate.tsx
@@ -1,20 +1,20 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Platform } from "react-native";
+
+const isSupported =
+  Platform.OS === "ios" &&
+  Number.parseFloat(String(Platform.Version)) >= 17.4;
 
 export const useInternalTranslateSheet = () => {
   const [isIOSTranslateSheetPresented, setIsIOSTranslateSheetPresented] =
     useState(false);
-  const [text, setText] = useState("");
-  const [opacity, setOpacity] = useState(0);
-
-  const isSupported =
-    Platform.OS === "ios" &&
-    Number.parseFloat(String(Platform.Version)) >= 17.4;
+  const textRef = useRef("");
+  const opacityRef = useRef(0);
 
   const presentIOSTranslateSheet = (_text: string, _opacity?: number) => {
+    textRef.current = _text;
+    opacityRef.current = _opacity ?? 0;
     setIsIOSTranslateSheetPresented(true);
-    setText(_text);
-    setOpacity(_opacity ?? 0);
   };
 
   const hideTranslateSheet = () => {
@@ -25,8 +25,8 @@ export const useInternalTranslateSheet = () => {
     isIOSTranslateSheetPresented,
     presentIOSTranslateSheet,
     hideTranslateSheet,
-    text,
-    opacity,
+    text: textRef.current,
+    opacity: opacityRef.current,
     isSupported,
   };
 };

--- a/src/hooks/useInternalTranslate.tsx
+++ b/src/hooks/useInternalTranslate.tsx
@@ -2,8 +2,7 @@ import { useRef, useState } from "react";
 import { Platform } from "react-native";
 
 const isSupported =
-  Platform.OS === "ios" &&
-  Number.parseFloat(String(Platform.Version)) >= 17.4;
+  Platform.OS === "ios" && Number.parseFloat(String(Platform.Version)) >= 17.4;
 
 export const useInternalTranslateSheet = () => {
   const [isIOSTranslateSheetPresented, setIsIOSTranslateSheetPresented] =


### PR DESCRIPTION
- Remove style creation in favour of predefined `StyleSheet.absoluteFillObject`
- Put `isSupported` calculations outside of the hook to have this running only once
- Replace `text` and `opacity` states with references to prevent redundant renders