### PR TITLE
feat: Add Translation Replacement Action Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ function MyComponent() {
 }
 ```
 
+### Replacement Action
+
+The Replacement Action feature allows you to capture and handle the translated text after a user completes a translation. This is particularly useful for:
+- Saving translations for later use
+- Updating UI elements with translated content
+- Implementing "translate and replace" functionality
+- Storing translations in your app's state or database
+
+#### Basic Usage
+
+To handle translated text, provide a callback function as the second parameter to `presentIOSTranslateSheet`:
+
+```tsx
+const { presentIOSTranslateSheet } = useIOSTranslateSheet();
+
+const handleTranslate = () => {
+  presentIOSTranslateSheet(
+    'Hello, how are you?',
+    (translatedText) => {
+      // Handle the translated text here
+      setTranslatedContent(translatedText);
+    }
+  );
+};
+```
+
+
 ### Checking Platform Support
 
 The `useIOSTranslateSheet` hook provides an `isSupported` boolean that you can use to check if the translation functionality is available on the current device:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.78.0):
     - hermes-engine/Pre-built (= 0.78.0)
   - hermes-engine/Pre-built (0.78.0)
-  - IOSTranslateSheet (1.1.7):
+  - IOSTranslateSheet (1.2.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1769,7 +1769,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  IOSTranslateSheet: 3ec1230530e64c9a3f60983011ca9c9f28033287
+  IOSTranslateSheet: 1ddfcb99b7daf8b06e9d8944a5e3b5545655bb80
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -9,7 +9,9 @@ export const Example = () => {
   const frText = "Salut le monde ! Ceci est un exemple de texte à traduire.";
 
   const handleTranslateEn = () => {
-    presentIOSTranslateSheet(enText);
+    presentIOSTranslateSheet(enText, (text) => {
+      console.log("Replacement action triggered:", text);
+    });
   };
 
   const handleTranslateFr = () => {

--- a/ios/IOSTranslateSheet.swift
+++ b/ios/IOSTranslateSheet.swift
@@ -4,7 +4,9 @@ import Translation
 class Props: ObservableObject {
     @Published var text: String = ""
     @Published var isPresented: Bool = false
+    @Published var hasReplacementAction: Bool = false
     @Published var onHide: () -> Void = {}
+    @Published var onReplacementAction: (String) -> Void = { _ in }
 }
 
 struct IOSTranslateSheet: View {
@@ -14,7 +16,11 @@ struct IOSTranslateSheet: View {
         if #available(iOS 17.4, *) {
             Color.clear
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .translationPresentation(isPresented: $props.isPresented, text: props.text)
+                .translationPresentation(
+                    isPresented: $props.isPresented,
+                    text: props.text,
+                    replacementAction: props.hasReplacementAction ? props.onReplacementAction : nil
+                )
                 .onChange(of: props.isPresented) { oldValue, newValue in
                     if oldValue == true && newValue == false {
                         props.onHide()

--- a/ios/IOSTranslateSheetProvider.swift
+++ b/ios/IOSTranslateSheetProvider.swift
@@ -33,10 +33,24 @@ public typealias RCTBubblingEventBlock = @convention(block) (_ body: [AnyHashabl
         }
     }
 
+    @objc public var hasReplacementAction: Bool = false {
+        didSet {
+            props.hasReplacementAction = hasReplacementAction
+        }
+    }
+
     @objc public var onHide: RCTBubblingEventBlock? {
         didSet {
             props.onHide = { [weak self] in
                 self?.onHide?([:])
+            }
+        }
+    }
+
+    @objc public var onReplacementAction: RCTBubblingEventBlock? {
+        didSet {
+            props.onReplacementAction = { [weak self] text in
+                self?.onReplacementAction?(["text": text])
             }
         }
     }

--- a/ios/IOSTranslateSheetView.mm
+++ b/ios/IOSTranslateSheetView.mm
@@ -43,7 +43,15 @@ using namespace facebook::react;
                     ->onHide({});
             }
         };
-        
+
+        _view.onReplacementAction = ^(NSDictionary *text) {
+            __typeof__(self) strongSelf = weakSelf;
+            if (strongSelf && strongSelf->_eventEmitter) {
+                std::dynamic_pointer_cast<const IOSTranslateSheetViewEventEmitter>(strongSelf->_eventEmitter)
+                    ->onReplacementAction({.text = [text[@"text"] UTF8String]});
+            }
+        };
+
         self.contentView = _view;
     }
     return self;
@@ -59,6 +67,9 @@ using namespace facebook::react;
     }
     if (oldViewProps.isPresented != newViewProps.isPresented) {
         _view.isPresented = newViewProps.isPresented;
+    }
+    if (oldViewProps.hasReplacementAction != newViewProps.hasReplacementAction) {
+        _view.hasReplacementAction = newViewProps.hasReplacementAction;
     }
 
     [super updateProps:props oldProps:oldProps];

--- a/ios/IOSTranslateSheetViewManager.mm
+++ b/ios/IOSTranslateSheetViewManager.mm
@@ -30,7 +30,9 @@ RCT_EXPORT_MODULE(IOSTranslateSheetView)
 
 RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 RCT_EXPORT_VIEW_PROPERTY(isPresented, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(hasReplacementAction, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onHide, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onReplacementAction, RCTDirectEventBlock)
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (BOOL)requiresMainQueueSetup

--- a/src/IOSTranslateSheetViewNativeComponent.ts
+++ b/src/IOSTranslateSheetViewNativeComponent.ts
@@ -2,10 +2,16 @@ import type { ViewProps } from "react-native";
 import type { DirectEventHandler } from "react-native/Libraries/Types/CodegenTypes";
 import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
 
+export interface OnReplacementActionEvent {
+  text: string;
+}
+
 interface IOSTranslateSheetProps extends ViewProps {
   text: string;
   isPresented: boolean;
+  hasReplacementAction: boolean;
   onHide: DirectEventHandler<null>;
+  onReplacementAction?: DirectEventHandler<OnReplacementActionEvent>;
 }
 
 export default codegenNativeComponent<IOSTranslateSheetProps>(

--- a/src/TranslateContext.tsx
+++ b/src/TranslateContext.tsx
@@ -1,11 +1,16 @@
 import { type ReactNode, createContext, useContext } from "react";
-import { StyleSheet } from "react-native";
-import IOSTranslateSheet from "./IOSTranslateSheetViewNativeComponent";
+import { type NativeSyntheticEvent, StyleSheet } from "react-native";
+import IOSTranslateSheet, {
+  type OnReplacementActionEvent,
+} from "./IOSTranslateSheetViewNativeComponent";
 import { useInternalTranslateSheet } from "./hooks/useInternalTranslate";
 
 type TranslateContextType = {
   isSupported: boolean;
-  presentIOSTranslateSheet: (text: string) => void;
+  presentIOSTranslateSheet: (
+    text: string,
+    replacementAction?: (text: string) => void,
+  ) => void;
 };
 
 const TranslateContext = createContext<TranslateContextType | null>(null);
@@ -19,7 +24,14 @@ export const IOSTranslateSheetProvider = ({
     text,
     hideTranslateSheet,
     isSupported,
+    replacementAction,
   } = useInternalTranslateSheet();
+
+  const onReplacementAction = (
+    event: NativeSyntheticEvent<OnReplacementActionEvent>,
+  ) => {
+    replacementAction?.(event.nativeEvent.text);
+  };
 
   return (
     <TranslateContext.Provider
@@ -33,6 +45,8 @@ export const IOSTranslateSheetProvider = ({
         isPresented={isIOSTranslateSheetPresented}
         onHide={hideTranslateSheet}
         style={StyleSheet.absoluteFillObject}
+        hasReplacementAction={!!replacementAction}
+        onReplacementAction={onReplacementAction}
       />
       {children}
     </TranslateContext.Provider>

--- a/src/hooks/useInternalTranslate.tsx
+++ b/src/hooks/useInternalTranslate.tsx
@@ -8,9 +8,14 @@ export const useInternalTranslateSheet = () => {
   const [isIOSTranslateSheetPresented, setIsIOSTranslateSheetPresented] =
     useState(false);
   const textRef = useRef("");
+  const replacementActionRef = useRef<(text: string) => void>(undefined);
 
-  const presentIOSTranslateSheet = (_text: string) => {
+  const presentIOSTranslateSheet = (
+    _text: string,
+    _replacementAction?: (text: string) => void,
+  ) => {
     textRef.current = _text;
+    replacementActionRef.current = _replacementAction;
     setIsIOSTranslateSheetPresented(true);
   };
 
@@ -24,5 +29,6 @@ export const useInternalTranslateSheet = () => {
     hideTranslateSheet,
     text: textRef.current,
     isSupported,
+    replacementAction: replacementActionRef.current,
   };
 };


### PR DESCRIPTION
Implements a new replacement action feature that allows capturing and handling translated text after translation completion. This enhancement enables more interactive translation workflows and better state management.

Key Changes:
- Added replacement action callback support in useInternalTranslateSheet hook
- Implemented native iOS support for handling translation replacement actions
- Updated TranslateContext to handle replacement action events
- Added hasReplacementAction flag and onReplacementAction event handler
- Updated documentation with replacement action usage examples

Technical Details:
- Extended IOSTranslateSheet native component with replacement action props
- Added Swift and Objective-C++ implementations for replacement action handling

Example Usage:
Now supports capturing translated text via callback:
presentIOSTranslateSheet('Hello', (translatedText) => {
  // Handle translated text
});

Platform Support:
- iOS 17.4+ required (unchanged)