### PR TITLE
fix: quickfix to support iPad

### DIFF
--- a/example/ios/IOSTranslateSheetExample.xcodeproj/project.pbxproj
+++ b/example/ios/IOSTranslateSheetExample.xcodeproj/project.pbxproj
@@ -276,8 +276,11 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.xtrapp.rniostranslatesheet;
 				PRODUCT_NAME = IOSTranslateSheetExample;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -304,7 +307,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.xtrapp.rniostranslatesheet;
 				PRODUCT_NAME = IOSTranslateSheetExample;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -378,10 +384,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -450,10 +453,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/IOSTranslateSheet.swift
+++ b/ios/IOSTranslateSheet.swift
@@ -19,6 +19,8 @@ struct IOSTranslateSheet: View {
                 .translationPresentation(
                     isPresented: $props.isPresented,
                     text: props.text,
+                    attachmentAnchor: .point(.bottom),
+                    arrowEdge: .bottom,
                     replacementAction: props.hasReplacementAction ? props.onReplacementAction : nil
                 )
                 .onChange(of: props.isPresented) { oldValue, newValue in


### PR DESCRIPTION
This way, the sheet displays well on iPad but always in the same place (at the bottom).

On iPad, the sheet should open from the button clicked on the RN side, but this requires to refactor the current implementation.

For resume, now it works on iPad, but the support can be greatly improved to correctly display the sheet in the right place.