### PR TITLE
fix: add componentProvider for iOS codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
     "android": {
       "javaPackageName": "com.iostranslatesheet"
     },
+    "ios": {
+      "componentProvider": {
+        "IOSTranslateSheetView": "IOSTranslateSheetView"
+      }
+    },
     "includesGeneratedCode": true
   },
   "create-react-native-library": {


### PR DESCRIPTION
When installing pods, there are following warning in the terminal output:
```
[Codegen] Crawling react-native-ios-translate-sheet library for components
[Codegen] Match found IOSTranslateSheetView -> IOSTranslateSheetView
[Codegen] [DEPRECATED] react-native-ios-translate-sheet should add the 'ios.componentProvider' property in their codegenConfig
```
Based on [this description](https://reactnative.dev/docs/the-new-architecture/using-codegen), this field is required in order to have an association between JS and native implementation.

It would be good to check how it builds after this change.