### PR TITLE
chore: modernize Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["npm", "github-actions"],
+  "extends": ["config:best-practices", ":automergeStableNonMajor"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "description": "Group React Native ecosystem updates for manual review",
+      "groupName": "React Native ecosystem",
+      "matchPackageNames": [
+        "react",
+        "react-native",
+        "@types/react",
+        "@react-native/**",
+        "@react-native-community/**",
+        "react-native-builder-bob",
+        "react-native-monorepo-config"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Require manual review for native dependency updates",
+      "matchManagers": ["bundler", "cocoapods", "gradle", "gradle-wrapper"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- adopt the Renovate best-practices preset
- automerge stable non-major updates only when checks pass
- group the React Native ecosystem and require manual review
- require manual review for Bundler, CocoaPods, Gradle, and Gradle wrapper updates
- let Renovate discover all supported managers, including nvm

## Validation

- Renovate config validator 44.49.1
- Biome check on renovate.json
- git diff --check

## Notes

The repository-wide lint currently sees local untracked Turbo cache files generated by previous native builds. The changed Renovate config itself passes Biome.