### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP registers the kotlin extension

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+  apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"


### PR DESCRIPTION
## Problem

Android Gradle Plugin 9 ships with built-in Kotlin support and registers the `kotlin` extension itself. When this library also applies `kotlin-android` unconditionally, Gradle configuration fails before compilation:

```
> Failed to apply plugin 'kotlin-android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```

Consumers should not need to disable AGP's built-in Kotlin support project-wide just to build this dependency, especially because that opt-out is removed in AGP 10.

## Change

Apply `kotlin-android` only when no `kotlin` extension has already been registered:

```groovy
if (project.extensions.findByName('kotlin') == null) {
  apply plugin: "kotlin-android"
}
```

The guard runs immediately after `com.android.library`, so AGP has already had a chance to register its extension.

| AGP | Built-in Kotlin | `kotlin` extension | Explicit plugin apply |
| --- | --- | --- | --- |
| 8.x | unavailable/off | absent | yes (unchanged) |
| 9.x | enabled | registered by AGP | no |
| 9.x | disabled | absent | yes |
| 10+ | enabled | registered by AGP | no |

## Verification

- `./gradlew :react-native-ios-translate-sheet:compileDebugKotlin` with AGP 9.2.1 / Gradle 9.4.1 and built-in Kotlin disabled
- Same module compilation with `-Pandroid.newDsl=true -Pandroid.builtInKotlin=true`
- `yarn lint`
- `yarn prepare`

For the built-in Kotlin build, the example app's own unconditional Kotlin plugin apply was guarded temporarily so Gradle could reach and validate the library module; that unrelated app change is not included here.

Adapted from huextrat/react-native-screenshot-aware#613.